### PR TITLE
Implement normalizer v1 for text-analysis

### DIFF
--- a/src/services/text-analysis/app/domain/__init__.py
+++ b/src/services/text-analysis/app/domain/__init__.py
@@ -1,0 +1,3 @@
+from app.domain.normalizer import normalize_text
+
+__all__ = ["normalize_text"]

--- a/src/services/text-analysis/app/domain/normalizer.py
+++ b/src/services/text-analysis/app/domain/normalizer.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import re
+
+_COLLAPSE_WHITESPACE_RE = re.compile(r"[\s\u00A0\u200B]+")
+_SPACE_BEFORE_PUNCT_RE = re.compile(r"\s+([,!?;.])")
+
+_REPEAT_EXCL_RE = re.compile(r"!{2,}")
+_REPEAT_QUEST_RE = re.compile(r"\?{2,}")
+_REPEAT_COMMA_RE = re.compile(r",{2,}")
+_REPEAT_SEMI_RE = re.compile(r";{2,}")
+_REPEAT_COLON_RE = re.compile(r":{2,}")
+_REPEAT_DOT_RE = re.compile(r"\.{4,}")
+
+
+def normalize_text(text: str) -> str:
+    value = text.replace("\r\n", "\n").replace("\r", "\n")
+    value = value.replace("\u00A0", " ")
+    value = value.replace("\u200B", "")
+    value = value.replace("…", "...")
+
+    value = _COLLAPSE_WHITESPACE_RE.sub(" ", value)
+    value = _SPACE_BEFORE_PUNCT_RE.sub(r"\1", value)
+
+    value = _REPEAT_DOT_RE.sub("...", value)
+    value = _REPEAT_EXCL_RE.sub("!", value)
+    value = _REPEAT_QUEST_RE.sub("?", value)
+    value = _REPEAT_COMMA_RE.sub(",", value)
+    value = _REPEAT_SEMI_RE.sub(";", value)
+    value = _REPEAT_COLON_RE.sub(":", value)
+
+    return value.strip()

--- a/src/services/text-analysis/app/main.py
+++ b/src/services/text-analysis/app/main.py
@@ -91,7 +91,7 @@ def analyze(payload: AnalyzeRequest, request: Request) -> AnalyzeResponse:
     if request.headers.get("x-force-error") == "1":
         raise RuntimeError("Forced test runtime error")
 
-    text = payload.text.strip()
+    text = payload.text
 
     cues: list[str] = []
     emotion = Emotion.NEUTRAL

--- a/src/services/text-analysis/app/models/segment.py
+++ b/src/services/text-analysis/app/models/segment.py
@@ -4,6 +4,8 @@ from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.domain.normalizer import normalize_text
+
 
 class Emotion(str, Enum):
     NEUTRAL = "neutral"
@@ -34,7 +36,7 @@ class SegmentMetadata(BaseModel):
     @field_validator("text")
     @classmethod
     def validate_text(cls, value: str) -> str:
-        normalized = value.strip()
+        normalized = normalize_text(value)
         if not normalized:
             raise ValueError("text must not be blank")
         return normalized
@@ -52,7 +54,16 @@ class SegmentMetadata(BaseModel):
 
 class AnalyzeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
     text: str = Field(..., min_length=1)
+
+    @field_validator("text")
+    @classmethod
+    def normalize_request_text(cls, value: str) -> str:
+        normalized = normalize_text(value)
+        if not normalized:
+            raise ValueError("text must not be blank")
+        return normalized
 
 
 class AnalyzeResponse(BaseModel):

--- a/src/services/text-analysis/tests/test_normalizer.py
+++ b/src/services/text-analysis/tests/test_normalizer.py
@@ -1,0 +1,21 @@
+from app.domain.normalizer import normalize_text
+
+
+def test_normalize_text_collapses_whitespace() -> None:
+    assert normalize_text("  Hello \n\t world  ") == "Hello world"
+
+
+def test_normalize_text_removes_space_before_punctuation() -> None:
+    assert normalize_text("Hello ! How are you ?") == "Hello! How are you?"
+
+
+def test_normalize_text_normalizes_unicode_ellipsis() -> None:
+    assert normalize_text("Wait …") == "Wait..."
+
+
+def test_normalize_text_collapses_repeated_punctuation() -> None:
+    assert normalize_text("Hello!!! What??? Yes,,,") == "Hello! What? Yes,"
+
+
+def test_normalize_text_removes_basic_text_noise() -> None:
+    assert normalize_text("Hi\u00A0\u200Bthere") == "Hi there"

--- a/src/services/text-analysis/tests/test_segment_model.py
+++ b/src/services/text-analysis/tests/test_segment_model.py
@@ -8,7 +8,7 @@ client = TestClient(app, raise_server_exceptions=False)
 
 def test_segment_model_validates_blank_text() -> None:
     try:
-        SegmentMetadata(text="   ", cues=[])
+        SegmentMetadata(text=" ", cues=[])
     except Exception as exc:
         assert "text must not be blank" in str(exc)
     else:
@@ -31,6 +31,38 @@ def test_analyze_returns_stable_segment_shape() -> None:
     assert "cues" in segment
 
 
+def test_analyze_normalizes_spaces_before_analysis() -> None:
+    response = client.post("/analyze", json={"text": "  Hello \n\t world  "})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["segments"][0]["text"] == "Hello world"
+
+
+def test_analyze_normalizes_repeated_punctuation_before_analysis() -> None:
+    response = client.post("/analyze", json={"text": "Hello!!!"})
+
+    assert response.status_code == 200
+    body = response.json()
+    segment = body["segments"][0]
+
+    assert segment["text"] == "Hello!"
+    assert "punctuation:exclamation" in segment["cues"]
+    assert segment["emotion"] == "excited"
+
+
+def test_analyze_normalizes_basic_text_noise_and_ellipsis() -> None:
+    response = client.post("/analyze", json={"text": " Wait \u00A0 …  "})
+
+    assert response.status_code == 200
+    body = response.json()
+    segment = body["segments"][0]
+
+    assert segment["text"] == "Wait..."
+    assert "punctuation:ellipsis" in segment["cues"]
+    assert segment["pause_ms"] == 300
+
+
 def test_analyze_validation_errors_use_shared_envelope() -> None:
     response = client.post("/analyze", json={})
 
@@ -50,6 +82,18 @@ def test_analyze_validation_errors_use_shared_envelope() -> None:
             ],
         }
     }
+
+
+def test_analyze_rejects_blank_text_after_normalization() -> None:
+    response = client.post("/analyze", json={"text": " \n\t "})
+
+    assert response.status_code == 422
+    body = response.json()
+
+    assert body["error"]["code"] == "validation_error"
+    assert body["error"]["path"] == "/analyze"
+    assert body["error"]["details"][0]["location"] == "body.text"
+    assert "text must not be blank" in body["error"]["details"][0]["message"]
 
 
 def test_analyze_runtime_errors_use_shared_envelope() -> None:


### PR DESCRIPTION
Refs #11 

What changed:
- added a dedicated normalizer module
- normalized spaces and basic text noise
- collapsed repeated punctuation
- cleaned input text before analysis
- added unit and API tests for normalization behavior

Manual verification:
- \"  Hello   world  \" -> \"Hello world\"
- \"Hello!!!\" -> \"Hello!\"
- \"  Wait ...  \" -> \"Wait...\"
- blank input returns 422 validation_error"