### PR TITLE
feat: implement rule-based emotion intensity scaling (0.0 to 1.0)

### DIFF
--- a/src/services/text-analysis/app/domain/mapper.py
+++ b/src/services/text-analysis/app/domain/mapper.py
@@ -14,9 +14,14 @@ class EmotionMapping:
 
 def map_emotion(signals: ExtractedSignals) -> EmotionMapping:
     if signals.has_positive_emoji:
-        return EmotionMapping(emotion=Emotion.HAPPY, intensity=0.7)
+        intensity = min(1.0, 0.5 + signals.positive_emoji_count * 0.2)
+        return EmotionMapping(emotion=Emotion.HAPPY, intensity=intensity)
 
     if signals.has_ellipsis:
         return EmotionMapping(emotion=Emotion.SAD, intensity=0.2)
+
+    if signals.has_exclamation:
+        intensity = min(1.0, signals.exclamation_count * 0.5)
+        return EmotionMapping(emotion=Emotion.EXCITED, intensity=intensity)
 
     return EmotionMapping(emotion=Emotion.NEUTRAL, intensity=0.0)

--- a/src/services/text-analysis/app/domain/signal_extractor.py
+++ b/src/services/text-analysis/app/domain/signal_extractor.py
@@ -26,6 +26,8 @@ class ExtractedSignals:
     has_mixed_punctuation: bool
     has_repeated_exclamation: bool
     has_repeated_question: bool
+    exclamation_count: int
+    positive_emoji_count: int
 
 
 def extract_signals(text: str) -> ExtractedSignals:
@@ -37,6 +39,9 @@ def extract_signals(text: str) -> ExtractedSignals:
     has_mixed_punctuation = "?!" in text or "!?" in text
     has_repeated_exclamation = "!!" in text
     has_repeated_question = "??" in text
+
+    exclamation_count = text.count("!")
+    positive_emoji_count = sum(1 for emoji in (*POSITIVE_EMOTICONS, *POSITIVE_UNICODE_EMOJIS) if emoji in text)
 
     if has_exclamation:
         cues.append("punctuation:exclamation")
@@ -62,4 +67,6 @@ def extract_signals(text: str) -> ExtractedSignals:
         has_mixed_punctuation=has_mixed_punctuation,
         has_repeated_exclamation=has_repeated_exclamation,
         has_repeated_question=has_repeated_question,
+        exclamation_count=exclamation_count,
+        positive_emoji_count=positive_emoji_count,
     )

--- a/src/services/text-analysis/tests/test_mapper.py
+++ b/src/services/text-analysis/tests/test_mapper.py
@@ -14,6 +14,8 @@ def test_map_emotion_defaults_to_neutral_without_cues() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=0,
         )
     )
 
@@ -32,6 +34,8 @@ def test_map_emotion_returns_happy_for_positive_emoji() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=1,
         )
     )
 
@@ -50,12 +54,13 @@ def test_map_emotion_returns_sad_for_ellipsis() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=0,
         )
     )
 
     assert mapping.emotion is Emotion.SAD
     assert mapping.intensity == 0.2
-
 
 
 def test_map_emotion_prefers_happy_over_sad_when_both_signals_exist() -> None:
@@ -69,8 +74,71 @@ def test_map_emotion_prefers_happy_over_sad_when_both_signals_exist() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=1,
         )
     )
 
     assert mapping.emotion is Emotion.HAPPY
     assert mapping.intensity == 0.7
+
+
+def test_map_emotion_scales_intensity_with_exclamation_count() -> None:
+    mapping = map_emotion(
+        ExtractedSignals(
+            cues=("punctuation:exclamation",),
+            has_exclamation=True,
+            has_question=False,
+            has_ellipsis=False,
+            has_positive_emoji=False,
+            has_mixed_punctuation=False,
+            has_repeated_exclamation=False,
+            has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=0,
+        )
+    )
+
+    assert mapping.emotion is Emotion.EXCITED
+    assert mapping.intensity == 0.5
+
+
+def test_map_emotion_scales_intensity_with_three_exclamations() -> None:
+    mapping = map_emotion(
+        ExtractedSignals(
+            cues=("punctuation:exclamation", "punctuation:repeated-exclamation"),
+            has_exclamation=True,
+            has_question=False,
+            has_ellipsis=False,
+            has_positive_emoji=False,
+            has_mixed_punctuation=False,
+            has_repeated_exclamation=True,
+            has_repeated_question=False,
+            exclamation_count=3,
+            positive_emoji_count=0,
+        )
+    )
+
+    assert mapping.emotion is Emotion.EXCITED
+    assert mapping.intensity == 1.0
+
+
+def test_map_emotion_scales_intensity_with_multiple_emojis() -> None:
+    mapping = map_emotion(
+        ExtractedSignals(
+            cues=("emoji:positive",),
+            has_exclamation=False,
+            has_question=False,
+            has_ellipsis=False,
+            has_positive_emoji=True,
+            has_mixed_punctuation=False,
+            has_repeated_exclamation=False,
+            has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=3,
+        )
+    )
+
+    assert mapping.emotion is Emotion.HAPPY
+    assert mapping.intensity == 1.0
+

--- a/src/services/text-analysis/tests/test_planner.py
+++ b/src/services/text-analysis/tests/test_planner.py
@@ -21,6 +21,8 @@ def test_plan_segment_combines_emotion_and_prosody_rules() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=1,
         ),
     )
 
@@ -50,6 +52,8 @@ def test_plan_segment_makes_exclamation_more_audible_than_neutral() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=0,
         ),
     )
     emphatic = plan_segment(
@@ -63,6 +67,8 @@ def test_plan_segment_makes_exclamation_more_audible_than_neutral() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=0,
         ),
     )
 
@@ -83,6 +89,8 @@ def test_plan_segment_keeps_ellipsis_more_subtle_than_before() -> None:
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=0,
+            positive_emoji_count=0,
         ),
     )
 
@@ -104,6 +112,8 @@ def test_plan_segment_amplifies_repeated_exclamation_more_than_single_exclamatio
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=0,
         ),
     )
     repeated = plan_segment(
@@ -117,6 +127,8 @@ def test_plan_segment_amplifies_repeated_exclamation_more_than_single_exclamatio
             has_mixed_punctuation=False,
             has_repeated_exclamation=True,
             has_repeated_question=False,
+            exclamation_count=3,
+            positive_emoji_count=0,
         ),
     )
 
@@ -136,6 +148,8 @@ def test_plan_segment_makes_mixed_punctuation_more_expressive_than_plain_exclama
             has_mixed_punctuation=False,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=0,
         ),
     )
     mixed = plan_segment(
@@ -149,6 +163,8 @@ def test_plan_segment_makes_mixed_punctuation_more_expressive_than_plain_exclama
             has_mixed_punctuation=True,
             has_repeated_exclamation=False,
             has_repeated_question=False,
+            exclamation_count=1,
+            positive_emoji_count=0,
         ),
     )
 

--- a/src/services/text-analysis/tests/test_segment_model.py
+++ b/src/services/text-analysis/tests/test_segment_model.py
@@ -53,8 +53,8 @@ def test_analyze_normalizes_repeated_punctuation_before_analysis() -> None:
 
     assert segment["text"] == "Hello!"
     assert segment["punctuation"] == ["exclamation"]
-    assert segment["emotion"] == "neutral"
-    assert segment["intensity"] == 0
+    assert segment["emotion"] == "joy"
+    assert segment["intensity"] == 2
 
 
 def test_analyze_normalizes_basic_text_noise_and_ellipsis() -> None:
@@ -97,8 +97,8 @@ def test_analyze_exposes_mixed_punctuation_in_shared_segment_metadata() -> None:
 
     assert segment["text"] == "Really?!"
     assert segment["punctuation"] == ["exclamation", "question", "mixed"]
-    assert segment["emotion"] == "neutral"
-    assert segment["intensity"] == 0
+    assert segment["emotion"] == "joy"
+    assert segment["intensity"] == 2
 
 
 def test_analyze_splits_normalized_repeated_punctuation_into_multiple_segments() -> None:
@@ -107,8 +107,8 @@ def test_analyze_splits_normalized_repeated_punctuation_into_multiple_segments()
     assert response.status_code == 200
     body = response.json()
     assert [segment["text"] for segment in body["segments"]] == ["Hello!", "What?"]
-    assert body["segments"][0]["emotion"] == "neutral"
-    assert body["segments"][0]["intensity"] == 0
+    assert body["segments"][0]["emotion"] == "joy"
+    assert body["segments"][0]["intensity"] == 2
     assert body["segments"][1]["punctuation"] == ["question"]
     assert body["segments"][1]["emotion"] == "neutral"
 

--- a/src/services/text-analysis/tests/test_signal_extractor.py
+++ b/src/services/text-analysis/tests/test_signal_extractor.py
@@ -13,6 +13,8 @@ def test_extract_signals_collects_known_cues() -> None:
     assert signals.has_mixed_punctuation is False
     assert signals.has_repeated_exclamation is False
     assert signals.has_repeated_question is False
+    assert signals.exclamation_count == 1
+    assert signals.positive_emoji_count == 1
     assert signals.cues == (
         "punctuation:exclamation",
         "punctuation:question",
@@ -25,6 +27,8 @@ def test_extract_signals_recognizes_unicode_positive_emoji() -> None:
     signals = extract_signals(f"I am happy {SMILING_FACE}")
 
     assert signals.has_positive_emoji is True
+    assert signals.positive_emoji_count == 1
+    assert signals.exclamation_count == 0
     assert signals.cues == ("emoji:positive",)
 
 
@@ -36,6 +40,8 @@ def test_extract_signals_combines_unicode_emoji_with_punctuation() -> None:
     assert signals.has_positive_emoji is True
     assert signals.has_ellipsis is True
     assert signals.has_mixed_punctuation is True
+    assert signals.exclamation_count == 1
+    assert signals.positive_emoji_count == 1
     assert signals.cues == (
         "punctuation:exclamation",
         "punctuation:question",
@@ -78,6 +84,7 @@ def test_extract_signals_recognizes_repeated_exclamation() -> None:
 
     assert signals.has_exclamation is True
     assert signals.has_repeated_exclamation is True
+    assert signals.exclamation_count == 3
     assert signals.cues == (
         "punctuation:exclamation",
         "punctuation:repeated-exclamation",

--- a/src/services/text-analysis/tests/test_signal_extractor_counts.py
+++ b/src/services/text-analysis/tests/test_signal_extractor_counts.py
@@ -1,0 +1,17 @@
+from app.domain.signal_extractor import extract_signals
+
+
+def test_extract_signals_counts_multiple_exclamations() -> None:
+    signals = extract_signals("Wow!!! Amazing!!!")
+
+    assert signals.exclamation_count == 6
+    assert signals.has_repeated_exclamation is True
+
+
+def test_extract_signals_counts_multiple_emojis() -> None:
+    SMILING_FACE = "\U0001F60A"
+    GRINNING_FACE = "\U0001F604"
+    signals = extract_signals(f"Happy {SMILING_FACE} and excited {GRINNING_FACE}")
+
+    assert signals.positive_emoji_count == 2
+    assert signals.has_positive_emoji is True


### PR DESCRIPTION
Implements #57

- Add exclamation_count and positive_emoji_count to ExtractedSignals
- Scale intensity dynamically based on punctuation frequency and emoji weight
- Map 1 '!' = 0.5 intensity, 3 '!!!' = 1.0 intensity (capped)
- Map positive emojis starting at 0.7, scaling with count
- Return EXCITED emotion for exclamation-only segments
- Update all tests to include new count fields and verify intensity scaling

All 51 tests pass.